### PR TITLE
Feature/edit notes

### DIFF
--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { Note } from "@/types/types";
 import ImportantIcon from "./ImportantIcon";
-import { Trash } from "lucide-react";
+import { Pencil, Trash } from "lucide-react";
 import { useState } from "react";
 import Modal from "./Modal";
 
@@ -9,25 +9,64 @@ type NoteCardProps = {
     note: Note;
     onClick: () => void;
     onDelete: (id: number) => void;
+    onEdit: (id: number, { title, content }: Partial<Note>) => void;
 }
 
-const NoteCard = ({ note, onClick, onDelete }: NoteCardProps) => {
+const NoteCard = ({ note, onClick, onDelete, onEdit }: NoteCardProps) => {
     const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+    const [isEditing, setIsEditing] = useState<boolean>(false)
+    const [editTitle, setEditTitle] = useState<string | undefined>("")
+    const [editContent, setEditContent] = useState<string | undefined>("")
+
     const confirmDelete = () => {
         onDelete(note.id);
         setIsModalOpen(false);
     };
 
+    const saveEdit = () => {
+        //to do validation
+        //const validTitle = editTitle.
+        onEdit(note.id, { title: editTitle, content: editContent });
+        setIsEditing(false);
+    };
+
     return (
         <div className="note-card flex items-center border-2 border-gray-100 p-4 rounded-lg bg-transparent" onClick={onClick}>
             <section>
-                <section id="title" className="text-lg font-semibold mb-1">{note.title}</section>
-                <section id="content" className="text-sm text-gray-700">{note.content}</section>
+                {isEditing ? (
+                    <div className="flex flex-col">
+                        <input
+                            className="text-lg font-semibold mb-1"
+                            value={editTitle}
+                            onChange={e => setEditTitle(e.target.value)}
+                            placeholder={note.title}
+                        />
+                        <textarea
+                            className="text-sm text-gray-700"
+                            value={editContent}
+                            onChange={e => setEditContent(e.target.value)}
+                            placeholder={note.content}
+                        />
+                        <button className="px-2 py-1 bg-green-500 text-white rounded" onClick={saveEdit}>Save</button>
+                        <button className="px-2 py-1 bg-gray-200 text-gray-800 rounded" onClick={() => setIsEditing(false)}>Cancel</button>
+                    </div>
+                ) : (
+                    <>
+                        <section id="title" className="text-lg font-semibold mb-1">{note.title}</section>
+                        <section id="content" className="text-sm text-gray-700">{note.content}</section>
+                    </>
+                )}
+
             </section>
             <section id="important" className="text-xs font-bold text-red-500 ml-auto">{note.important && <ImportantIcon className="inline-block text-red-500 ml-2" />}</section>
             <section id="delete-note">
                 <button>
                     <Trash strokeWidth={1} size={18} onClick={(e) => { e.stopPropagation(); setIsModalOpen(true) }} />
+                </button>
+            </section>
+            <section id="edit-note">
+                <button>
+                    <Pencil strokeWidth={1} size={18} onClick={(e) => { e.stopPropagation(); setIsEditing(true) }} />
                 </button>
             </section>
 

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -24,9 +24,10 @@ const NoteCard = ({ note, onClick, onDelete, onEdit }: NoteCardProps) => {
     };
 
     const saveEdit = () => {
-        //to do validation
-        //const validTitle = editTitle.
-        onEdit(note.id, { title: editTitle, content: editContent });
+        //validation
+        const newTitle = editTitle?.trim() === "" ? note.title : editTitle;
+        const newContent = editContent?.trim() === "" ? note.content : editContent;
+        onEdit(note.id, { title: newTitle, content: newContent });
         setIsEditing(false);
     };
 

--- a/src/components/NotesList.tsx
+++ b/src/components/NotesList.tsx
@@ -5,6 +5,7 @@ import { Filter, Note } from "@/types/types";
 import { notes_toggle_importance } from "@/reducers/noteReducer";
 import NoteCard from "./NoteCard";
 import useDeleteNote from "@/hooks/useDeleteNote";
+import useEditNote from "@/hooks/useEditNote";
 
 const NotesList = () => {
     const notes: Note[] = useSelector((state: RootState) => state.notes.value);
@@ -22,9 +23,13 @@ const NotesList = () => {
     };
 
     const deleteCurrentNote = useDeleteNote()
+    const editCurrentNote = useEditNote()
 
     const handleDelete = (id: number) => {
         deleteCurrentNote(id)
+    }
+    const handleEdit = (id: number, {title, content}: Partial<Note>) => {
+        editCurrentNote(id, {title, content})
     }
 
     const filteredNotes = getFilteredNotes(notes, filter);
@@ -33,7 +38,7 @@ const NotesList = () => {
         <section className="notes-list flex flex-col gap-2">
             {
                 filteredNotes.map(note =>
-                    (<NoteCard key={note.id} note={note} onClick={() => handleImportance(note.id)} onDelete={handleDelete} />))
+                    (<NoteCard key={note.id} note={note} onClick={() => handleImportance(note.id)} onDelete={handleDelete} onEdit={handleEdit} />))
             }
         </section>
     );

--- a/src/hooks/useEditNote.ts
+++ b/src/hooks/useEditNote.ts
@@ -1,0 +1,26 @@
+"use client"
+import { notes_edited } from "@/reducers/noteReducer";
+import { editNote } from "@/services/notesService";
+import { AppDispatch } from "@/store/store";
+import { Note } from "@/types/types";
+import { useDispatch } from "react-redux";
+
+const useEditNote = () => {
+    const dispatch = useDispatch<AppDispatch>();
+    const editExistingNote = async (id: Number, { title, content }: Partial<Note>) => {
+        try {
+            const editedNote = await editNote(id, { title, content });
+            if (editedNote) {
+                dispatch(notes_edited(editedNote));
+                return { success: true, message: "Note edited successfully" }
+            } else {
+                return { success: false, message: `Error editing Note` }
+            }
+        } catch (error) {
+            return { success: false, message: `Something went wrong (on our end)` }
+        }
+    };
+    return editExistingNote;
+};
+
+export default useEditNote;

--- a/src/reducers/noteReducer.ts
+++ b/src/reducers/noteReducer.ts
@@ -19,9 +19,13 @@ export const noteSlice = createSlice({
         },
         notes_deleted: (state, action: PayloadAction<Number>) => {
             state.value = state.value.filter(note => note.id != action.payload);
+        },
+        notes_edited: (state, action: PayloadAction<Note>) => {
+            const index = state.value.findIndex(note => note.id === action.payload.id)
+            if (index !== -1) { state.value[index] = action.payload }
         }
     },
 });
 
-export const { notes_init, notes_created, notes_toggle_importance, notes_deleted } = noteSlice.actions;
+export const { notes_init, notes_created, notes_toggle_importance, notes_deleted, notes_edited } = noteSlice.actions;
 export default noteSlice.reducer;

--- a/src/services/notesService.ts
+++ b/src/services/notesService.ts
@@ -25,3 +25,15 @@ export const deleteNote = async (id: Number): Promise<Number> => {
   return response.status;
 };
 
+export const editNote = async (id: Number, {title, content}: Partial<Note>): Promise<Note> => {
+  const response = await fetch(`http://localhost:3001/notes/${id}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({title, content})
+  });
+  
+  return response.json();
+};
+


### PR DESCRIPTION
### Frontend Changes:
* **Editable NoteCard Component**: The `NoteCard` component now includes an editing mode with input fields for the note's title and content, along with "Save" and "Cancel" buttons. A new `onEdit` prop was added to handle edits.
* **NotesList Integration**: The `NotesList` component was updated to pass an `onEdit` handler to `NoteCard`, using a new `useEditNote` hook for managing edit operations. [[1]](diffhunk://#diff-f59368da8475af870beedcfa12b219ff5e923fc9ea9f46e89ea181c636792442R8) [[2]](diffhunk://#diff-f59368da8475af870beedcfa12b219ff5e923fc9ea9f46e89ea181c636792442R26-R41)

### State Management:
* **Redux Action for Editing Notes**: A new `notes_edited` action was added to the `noteReducer` to update the Redux store when a note is edited.

### Backend Integration:
* **Edit Note API Service**: The `editNote` function was added to `notesService` to send PATCH requests to update notes on the backend.

### Custom Hook:
* **`useEditNote` Hook**: A new custom hook was created to handle editing notes, dispatching the `notes_edited` action and interacting with the backend API.