### PR TITLE
Feature/guest notes persistence

### DIFF
--- a/src/components/__tests__/NoteCard.test.tsx
+++ b/src/components/__tests__/NoteCard.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import NoteCard from "../notes_content/NoteCard";
-import { Note } from "@/types/types";
+import { Note, NoteForRedux } from "@/types/types";
 import React from "react";
 
 /*jest.mock("../NoteMenu", () => {
@@ -11,12 +11,15 @@ import React from "react";
 });*/
 
 describe("NoteCard", () => {
-    const note: Note = {
+    const note: NoteForRedux = {
         id: 1,
         title: "Test title",
         content: "This is the content of the note",
         color: "default",
         important: false,
+        createdAt: "today",
+        updatedAt: "today",
+        userId: null,
     };
 
 
@@ -112,7 +115,8 @@ describe("NoteCard", () => {
         const saveEditButton = screen.getByLabelText("Save edit note");
         await user.click(saveEditButton);
 
-        expect(onEditMock).toHaveBeenCalledWith(editedNote.id, {
+        expect(onEditMock).toHaveBeenCalledWith({
+            id: editedNote.id,
             title: editedNote.title,
             content: editedNote.content,
         });

--- a/src/components/notes_content/DropdownMenu.tsx
+++ b/src/components/notes_content/DropdownMenu.tsx
@@ -45,14 +45,15 @@ const DropdownMenu = ({ trigger, items, className, menuClassName }: DropdownMenu
 
     return (
         <div ref={menuRef} className={`relative ${className}`}>
-            <div ref={refs.setReference} onClick={() => setOpen(!open)}>
+            <button ref={refs.setReference} onClick={() => setOpen(!open)} aria-label="Opciones" style={{ background: "none", border: "none", padding: 0, cursor: "pointer" }}>
                 {trigger}
-            </div>
+            </button>
             {open && (
                 <div
                     ref={refs.setFloating}
                     style={{ position: strategy, top: y ?? 0, left: x ?? 0 }}
                     className={`bg-white dark:bg-[#202124] rounded shadow-md ${menuClassName}`}
+                    aria-label="Opciones"
                 >
                     {items.map((item, index) => (
                         <div key={index} className="relative">

--- a/src/components/notes_content/NoteCard.tsx
+++ b/src/components/notes_content/NoteCard.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { Note, NoteForRedux } from "@/types/types";
+import { EditNote, Note, NoteForRedux } from "@/types/types";
 import { useState } from "react";
 import Modal from "../ui/Modal";
 import NoteMenu from "./NoteMenu";
@@ -11,7 +11,7 @@ type NoteCardProps = {
     note: NoteForRedux;
     onClick: () => void;
     onDelete: (id: number) => void;
-    onEdit: ({id, title, content }: Partial<Note>) => void;
+    onEdit: ({id, title, content }: EditNote) => void;
     onChangeColor: (id: number, color: string) => void;
 }
 

--- a/src/components/notes_content/NoteCard.tsx
+++ b/src/components/notes_content/NoteCard.tsx
@@ -11,7 +11,7 @@ type NoteCardProps = {
     note: NoteForRedux;
     onClick: () => void;
     onDelete: (id: number) => void;
-    onEdit: ({id, title, content }: EditNote) => void;
+    onEdit: ({ id, title, content }: EditNote) => void;
     onChangeColor: (id: number, color: string) => void;
 }
 
@@ -43,7 +43,7 @@ const NoteCard = ({ note, onClick, onDelete, onEdit, onChangeColor }: NoteCardPr
             </section>
             <section id="note-card--side" className="flex items-center">
                 <section id="note-card--important" className="text-xs font-bold ml-auto">{note.important && <Star strokeWidth={2} size={18} color="#8E44AD" className="inline-block ml-2" />}</section>
-                <section id="note-card--menu" className=""><NoteMenu onDelete={() => setIsModalOpen(true)} onEdit={() => setIsEditing(true)} onChangeColor={handleChangeColor} /></section>
+                <section id="note-card--menu" className=""><NoteMenu onDelete={() => setIsModalOpen(true)} onEdit={() => setIsEditing(true)} onChangeColor={handleChangeColor} aria-label="Opciones" /></section>
             </section>
 
             <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>

--- a/src/components/notes_content/NoteCard.tsx
+++ b/src/components/notes_content/NoteCard.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { Note } from "@/types/types";
+import { Note, NoteForRedux } from "@/types/types";
 import { useState } from "react";
 import Modal from "../ui/Modal";
 import NoteMenu from "./NoteMenu";
@@ -8,7 +8,7 @@ import NoteEditForm from "../notes_forms/NoteEditForm";
 import NoteContent from "./NoteContent";
 
 type NoteCardProps = {
-    note: Note;
+    note: NoteForRedux;
     onClick: () => void;
     onDelete: (id: number) => void;
     onEdit: ({id, title, content }: Partial<Note>) => void;

--- a/src/components/notes_content/NoteContent.tsx
+++ b/src/components/notes_content/NoteContent.tsx
@@ -1,7 +1,7 @@
-import { Note } from "@/types/types";
+import { Note, NoteForRedux } from "@/types/types";
 
 type NoteContentProps = {
-    note: Note;
+    note: NoteForRedux;
 };
 
 const NoteContent = ({ note }: NoteContentProps) => {

--- a/src/components/notes_content/NoteMenu.tsx
+++ b/src/components/notes_content/NoteMenu.tsx
@@ -52,6 +52,7 @@ const NoteMenu = ({ onEdit, onDelete, onChangeColor }: NoteMenuProps) => {
         <DropdownMenu
             trigger={<MoreVertical strokeWidth={1} size={18} />}
             items={menuItems}
+            aria-label="Opciones"
         />
     );
 };

--- a/src/components/notes_content/NotesList.tsx
+++ b/src/components/notes_content/NotesList.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../store/store";
-import { Filter, Note } from "@/types/types";
+import { Filter, Note, NoteForRedux } from "@/types/types";
 import { notes_toggle_importance } from "@/reducers/noteReducer";
 import NoteCard from "./NoteCard";
 import useDeleteNote from "@/hooks/notes/useDeleteNote";
@@ -11,7 +11,7 @@ import { getFilteredNotes } from "@/utils/getFilteredNotes";
 import styles from "./NotesList.module.css";
 
 const NotesList = () => {
-    const notes: Note[] = useSelector((state: RootState) => state.notes.value);
+    const notes: NoteForRedux[] = useSelector((state: RootState) => state.notes.value);
     const filter: Filter = useSelector((state: RootState) => state.filter.value);
     const dispatch = useDispatch();
 

--- a/src/components/notes_content/NotesList.tsx
+++ b/src/components/notes_content/NotesList.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../store/store";
-import { Filter, Note, NoteForRedux } from "@/types/types";
+import { EditNote, Filter, Note, NoteForRedux } from "@/types/types";
 import { notes_toggle_importance } from "@/reducers/noteReducer";
 import NoteCard from "./NoteCard";
 import useDeleteNote from "@/hooks/notes/useDeleteNote";
@@ -26,7 +26,7 @@ const NotesList = () => {
     const handleDelete = (id: number) => {
         deleteCurrentNote(id)
     }
-    const handleEdit = ({ id, title, content }: Partial<Note>) => {
+    const handleEdit = ({ id, title, content }: EditNote) => {
         editCurrentNote({ id, title, content })
     }
 

--- a/src/components/notes_forms/NoteEditForm.tsx
+++ b/src/components/notes_forms/NoteEditForm.tsx
@@ -1,8 +1,8 @@
-import { Note } from "@/types/types";
+import { Note, NoteForRedux } from "@/types/types";
 import { useState } from "react";
 
 type NoteEditFormProps = {
-    note: Note,
+    note: NoteForRedux,
     setIsEditing: React.Dispatch<React.SetStateAction<boolean>>,
     onEdit: ({ id, title, content }: Partial<Note>) => void
 }

--- a/src/components/notes_forms/NoteEditForm.tsx
+++ b/src/components/notes_forms/NoteEditForm.tsx
@@ -1,10 +1,10 @@
-import { Note, NoteForRedux } from "@/types/types";
+import { EditNote, Note, NoteForRedux } from "@/types/types";
 import { useState } from "react";
 
 type NoteEditFormProps = {
     note: NoteForRedux,
     setIsEditing: React.Dispatch<React.SetStateAction<boolean>>,
-    onEdit: ({ id, title, content }: Partial<Note>) => void
+    onEdit: ({ id, title, content }: EditNote) => void
 }
 
 const NoteEditForm = ({ note, setIsEditing, onEdit }: NoteEditFormProps) => {

--- a/src/hooks/notes/useCreateNote.ts
+++ b/src/hooks/notes/useCreateNote.ts
@@ -3,13 +3,15 @@ import { notes_created } from "@/reducers/noteReducer";
 import { createNote } from "@/services/notesService";
 import { AppDispatch } from "@/store/store";
 import { NewNote, Note } from "@/types/types";
+import { parseNoteFromDb } from "@/utils/parseNotes";
 import { useDispatch } from "react-redux";
 
 const useCreateNote = () => {
     const dispatch = useDispatch<AppDispatch>();
-    const addNewNote =  async (note: NewNote) => {
+    const addNewNote = async (note: NewNote) => {
         const noteCreated = await createNote(note);
-        dispatch(notes_created(noteCreated));
+        const reduxNote = parseNoteFromDb(noteCreated)
+        dispatch(notes_created(reduxNote));
     };
     return addNewNote;
 };

--- a/src/hooks/notes/useCreateNote.ts
+++ b/src/hooks/notes/useCreateNote.ts
@@ -3,15 +3,27 @@ import { notes_created } from "@/reducers/noteReducer";
 import { createNote } from "@/services/notesService";
 import { AppDispatch } from "@/store/store";
 import { NewNote, Note } from "@/types/types";
-import { parseNoteFromDb } from "@/utils/parseNotes";
+import { saveGuestNote } from "@/utils/localStorageNotes";
+import { parseLocalNote, parseNoteFromDb } from "@/utils/parseNotes";
+import { useSession } from "next-auth/react";
 import { useDispatch } from "react-redux";
 
 const useCreateNote = () => {
     const dispatch = useDispatch<AppDispatch>();
+    const { data: session } = useSession();
     const addNewNote = async (note: NewNote) => {
-        const noteCreated = await createNote(note);
-        const reduxNote = parseNoteFromDb(noteCreated)
-        dispatch(notes_created(reduxNote));
+        if (!session) {
+            //without user session from localStorage
+            //async?
+            saveGuestNote(note);
+            const reduxNote = parseLocalNote(note)
+            dispatch(notes_created(reduxNote));
+        } else {
+            //with user session from db
+            const noteCreated = await createNote(note);
+            const reduxNote = parseNoteFromDb(noteCreated)
+            dispatch(notes_created(reduxNote));
+        };
     };
     return addNewNote;
 };

--- a/src/hooks/notes/useCreateNote.ts
+++ b/src/hooks/notes/useCreateNote.ts
@@ -11,12 +11,12 @@ import { useDispatch } from "react-redux";
 const useCreateNote = () => {
     const dispatch = useDispatch<AppDispatch>();
     const { data: session } = useSession();
-    const addNewNote = async (note: NewNote) => {
+    const addNewNote = async (note: NewNote) => { //to do add error handling
         if (!session) {
             //without user session from localStorage
             //async?
-            saveGuestNote(note);
             const reduxNote = parseLocalNote(note)
+            saveGuestNote(reduxNote);            
             dispatch(notes_created(reduxNote));
         } else {
             //with user session from db

--- a/src/hooks/notes/useDeleteNote.ts
+++ b/src/hooks/notes/useDeleteNote.ts
@@ -2,21 +2,35 @@
 import { notes_deleted } from "@/reducers/noteReducer";
 import { deleteNote } from "@/services/notesService";
 import { AppDispatch } from "@/store/store";
+import { deleteGuestNotes } from "@/utils/localStorageNotes";
+import { useSession } from "next-auth/react";
 import { useDispatch } from "react-redux";
 
 const useDeleteNote = () => {
     const dispatch = useDispatch<AppDispatch>();
+    const { data: session } = useSession();
     const deleteExistingNote = async (id: Number) => {
-        try {
-            const status = await deleteNote(id);
-            if (status === 200 || status === 204) {
-                dispatch(notes_deleted(id));
-                return { success: true, message: "Note deleted successfully" }
+        if (!session) {
+            const isDeleted = deleteGuestNotes(id);
+            if (!isDeleted.success) {
+                console.error(isDeleted.message);
+                return { success: false, message: isDeleted.message }
             } else {
-                return { success: false, message: `Error deleting Note. Status code: ${status}` }
+                dispatch(notes_deleted(id));
+                return { success: true, message: "Note edited!", status: isDeleted.status }
+            };
+        } else {
+            try {
+                const status = await deleteNote(id);
+                if (status === 200 || status === 204) {
+                    dispatch(notes_deleted(id));
+                    return { success: true, message: "Note deleted successfully" }
+                } else {
+                    return { success: false, message: `Error deleting Note. Status code: ${status}` }
+                }
+            } catch (error) {
+                return { success: false, message: `Something went wrong (on our end)` }
             }
-        } catch (error) {
-            return { success: false, message: `Something went wrong (on our end)` }
         }
     };
     return deleteExistingNote;

--- a/src/hooks/notes/useEditNote.ts
+++ b/src/hooks/notes/useEditNote.ts
@@ -3,6 +3,7 @@ import { notes_edited } from "@/reducers/noteReducer";
 import { editNote } from "@/services/notesService";
 import { AppDispatch } from "@/store/store";
 import { Note } from "@/types/types";
+import { parseNoteFromDb } from "@/utils/parseNotes";
 import { useDispatch } from "react-redux";
 
 const useEditNote = () => {
@@ -11,7 +12,8 @@ const useEditNote = () => {
         try {
             const editedNote = await editNote({ id, title, content });
             if (editedNote) {
-                dispatch(notes_edited(editedNote));
+                const reduxEditedNote = parseNoteFromDb(editedNote)
+                dispatch(notes_edited(reduxEditedNote));
                 return { success: true, message: "Note edited successfully" }
             } else {
                 return { success: false, message: `Error editing Note` }

--- a/src/hooks/notes/useEditNote.ts
+++ b/src/hooks/notes/useEditNote.ts
@@ -2,25 +2,39 @@
 import { notes_edited } from "@/reducers/noteReducer";
 import { editNote } from "@/services/notesService";
 import { AppDispatch } from "@/store/store";
-import { Note } from "@/types/types";
+import { EditNote } from "@/types/types";
+import { editGuestNotes } from "@/utils/localStorageNotes";
 import { parseNoteFromDb } from "@/utils/parseNotes";
+import { useSession } from "next-auth/react";
 import { useDispatch } from "react-redux";
 
 const useEditNote = () => {
     const dispatch = useDispatch<AppDispatch>();
-    const editExistingNote = async ({ id, title, content }: Partial<Note>) => {
-        try {
-            const editedNote = await editNote({ id, title, content });
-            if (editedNote) {
-                const reduxEditedNote = parseNoteFromDb(editedNote)
-                dispatch(notes_edited(reduxEditedNote));
-                return { success: true, message: "Note edited successfully" }
+    const { data: session } = useSession();
+    const editExistingNote = async ({ id, title, content }: EditNote) => {
+        if (!session) {            
+            const isEdited = editGuestNotes({ id, title, content });
+            if (!isEdited.success) {
+                console.error(isEdited.message);
+                return { success: false, message: isEdited.message }
             } else {
-                return { success: false, message: `Error editing Note` }
+                dispatch(notes_edited(isEdited.note));
+                return { success: true, message: "Note edited!" }
+            };
+        } else {
+            try {
+                const editedNote = await editNote({ id, title, content });
+                if (editedNote) {
+                    const reduxEditedNote = parseNoteFromDb(editedNote)
+                    dispatch(notes_edited(reduxEditedNote));
+                    return { success: true, message: "Note edited successfully" }
+                } else {
+                    return { success: false, message: `Error editing Note` }
+                }
+            } catch (error) {
+                return { success: false, message: `Something went wrong (on our end)` }
             }
-        } catch (error) {
-            return { success: false, message: `Something went wrong (on our end)` }
-        }
+        };
     };
     return editExistingNote;
 };

--- a/src/hooks/useNotesInit.ts
+++ b/src/hooks/useNotesInit.ts
@@ -3,42 +3,37 @@ import { notes_init } from "@/reducers/noteReducer";
 import { NewNote, Note, NoteForRedux } from "@/types/types";
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@auth";
 import { getGuestNotes } from "@/utils/localStorageNotes";
+import { useSession } from "next-auth/react";
 
 const useNotesInit = (notes: Note[]) => {
     const dispatch = useDispatch();
+    const { data: session } = useSession();
     useEffect(() => {
-        const init = async () => {
-            const session = await getServerSession(authOptions);
-            let notesForRedux: NoteForRedux[] = [];
-            if (session?.user) {
-                //with user session from db
-                notesForRedux = notes.map(note => ({
-                    ...note,
-                    createdAt: typeof note.createdAt === "string" ? note.createdAt : note.createdAt.toISOString(),
-                    updatedAt: typeof note.updatedAt === "string" ? note.updatedAt : note.updatedAt.toISOString(),
-                }));
-            } else {
-                //without user session from localStorage
-                const localNotes = getGuestNotes();
-                notesForRedux = localNotes.map(note => ({
-                    id: new Date().getTime(),
-                    title: note.title,
-                    content: note.content,
-                    important: note.important ?? false,
-                    color: note.color ?? "default",
-                    createdAt: new Date().toISOString(),
-                    updatedAt: new Date().toISOString(),
-                    userId: null,
-                }));
-            };
-            dispatch(notes_init(notesForRedux));
+        let notesForRedux: NoteForRedux[] = [];
+        if (!session) {
+            //without user session from localStorage
+            const localNotes = getGuestNotes();
+            notesForRedux = localNotes.map(note => ({
+                id: new Date().getTime(),
+                title: note.title,
+                content: note.content,
+                important: note.important ?? false,
+                color: note.color ?? "default",
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+                userId: null,
+            }));
+        } else {
+            //with user session from db
+            notesForRedux = notes.map(note => ({
+                ...note,
+                createdAt: typeof note.createdAt === "string" ? note.createdAt : note.createdAt.toISOString(),
+                updatedAt: typeof note.updatedAt === "string" ? note.updatedAt : note.updatedAt.toISOString(),
+            }));
         };
-
-        init();
-    }, [dispatch, notes]);
+        dispatch(notes_init(notesForRedux));
+    }, [dispatch, notes, session]);
 };
 
 export default useNotesInit;

--- a/src/hooks/useNotesInit.ts
+++ b/src/hooks/useNotesInit.ts
@@ -1,10 +1,11 @@
 "use client"
 import { notes_init } from "@/reducers/noteReducer";
-import { NewNote, Note, NoteForRedux } from "@/types/types";
+import { Note, NoteForRedux } from "@/types/types";
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { getGuestNotes } from "@/utils/localStorageNotes";
 import { useSession } from "next-auth/react";
+import { parseLocalNotes, parseNotesFromDb } from "@/utils/parseNotes";
 
 const useNotesInit = (notes: Note[]) => {
     const dispatch = useDispatch();
@@ -14,23 +15,10 @@ const useNotesInit = (notes: Note[]) => {
         if (!session) {
             //without user session from localStorage
             const localNotes = getGuestNotes();
-            notesForRedux = localNotes.map(note => ({
-                id: new Date().getTime(),
-                title: note.title,
-                content: note.content,
-                important: note.important ?? false,
-                color: note.color ?? "default",
-                createdAt: new Date().toISOString(),
-                updatedAt: new Date().toISOString(),
-                userId: null,
-            }));
+            notesForRedux = parseLocalNotes(localNotes);
         } else {
             //with user session from db
-            notesForRedux = notes.map(note => ({
-                ...note,
-                createdAt: typeof note.createdAt === "string" ? note.createdAt : note.createdAt.toISOString(),
-                updatedAt: typeof note.updatedAt === "string" ? note.updatedAt : note.updatedAt.toISOString(),
-            }));
+            notesForRedux = parseNotesFromDb(notes);
         };
         dispatch(notes_init(notesForRedux));
     }, [dispatch, notes, session]);

--- a/src/hooks/useNotesInit.ts
+++ b/src/hooks/useNotesInit.ts
@@ -1,18 +1,43 @@
 "use client"
 import { notes_init } from "@/reducers/noteReducer";
-import { Note, NoteForRedux } from "@/types/types";
+import { NewNote, Note, NoteForRedux } from "@/types/types";
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@auth";
+import { getGuestNotes } from "@/utils/localStorageNotes";
 
 const useNotesInit = (notes: Note[]) => {
     const dispatch = useDispatch();
     useEffect(() => {
-        const serializedNotes: NoteForRedux[] = notes.map(note => ({
-            ...note,
-            createdAt: typeof note.createdAt === "string" ? note.createdAt : note.createdAt.toISOString(),
-            updatedAt: typeof note.updatedAt === "string" ? note.updatedAt : note.updatedAt.toISOString(),
-        }));
-        dispatch(notes_init(serializedNotes))
+        const init = async () => {
+            const session = await getServerSession(authOptions);
+            let notesForRedux: NoteForRedux[] = [];
+            if (session?.user) {
+                //with user session from db
+                notesForRedux = notes.map(note => ({
+                    ...note,
+                    createdAt: typeof note.createdAt === "string" ? note.createdAt : note.createdAt.toISOString(),
+                    updatedAt: typeof note.updatedAt === "string" ? note.updatedAt : note.updatedAt.toISOString(),
+                }));
+            } else {
+                //without user session from localStorage
+                const localNotes = getGuestNotes();
+                notesForRedux = localNotes.map(note => ({
+                    id: new Date().getTime(),
+                    title: note.title,
+                    content: note.content,
+                    important: note.important ?? false,
+                    color: note.color ?? "default",
+                    createdAt: new Date().toISOString(),
+                    updatedAt: new Date().toISOString(),
+                    userId: null,
+                }));
+            };
+            dispatch(notes_init(notesForRedux));
+        };
+
+        init();
     }, [dispatch, notes]);
 };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -5,14 +5,16 @@ export type NewNote = {
     content: string;
     important: boolean;
     color: string;
-    userId?: number;
+    userId?: string | null;
 };
 
 export type Note = PrismaNote;
 
-export type EditNote = NewNote & {
-    id: number
-}
+export type EditNote = {
+    id: number;
+    title: string | undefined;
+    content: string | undefined;
+};
 
 export type NotesState = {
     value: Note[];
@@ -40,3 +42,6 @@ export type UserState = {
     value: User;
 };
 
+export type EditGuestNoteResult =
+    | { success: true; note: NoteForRedux }
+    | { success: false; message: string };

--- a/src/utils/getFilteredNotes.ts
+++ b/src/utils/getFilteredNotes.ts
@@ -1,6 +1,6 @@
-import { Filter, Note } from "@/types/types";
+import { Filter, NoteForRedux } from "@/types/types";
 
-export const getFilteredNotes = (notes: Note[], filter: Filter) => {
+export const getFilteredNotes = (notes: NoteForRedux[], filter: Filter) => {
     if (filter === "important") return notes.filter(note => note.important === true);
     if (filter === "not_important") return notes.filter(note => note.important === false);
     return notes;

--- a/src/utils/localStorageNotes.ts
+++ b/src/utils/localStorageNotes.ts
@@ -3,17 +3,17 @@ import { NewNote } from "../types/types";
 export const saveGuestNotes = (notes: NewNote[]) => {
     try {
         localStorage.setItem("localStorageNotes", JSON.stringify(notes));
-    } catch {
+    } catch (error) {
         console.error("Something went wrong, sorry", error);
     }
 };
 
-export const getGuestNotes = (notes: Note[]) => {
+export const getGuestNotes = () => {
     try {
         const guestNotes = localStorage.getItem("localStorageNotes");
         if (!guestNotes) return [];
         return JSON.parse(guestNotes);
-    } catch {
+    } catch (error) {
         return [];
     }
 };

--- a/src/utils/localStorageNotes.ts
+++ b/src/utils/localStorageNotes.ts
@@ -1,0 +1,19 @@
+import { NewNote } from "../types/types";
+
+export const saveGuestNotes = (notes: NewNote[]) => {
+    try {
+        localStorage.setItem("localStorageNotes", JSON.stringify(notes));
+    } catch {
+        console.error("Something went wrong, sorry", error);
+    }
+};
+
+export const getGuestNotes = (notes: Note[]) => {
+    try {
+        const guestNotes = localStorage.getItem("localStorageNotes");
+        if (!guestNotes) return [];
+        return JSON.parse(guestNotes);
+    } catch {
+        return [];
+    }
+};

--- a/src/utils/localStorageNotes.ts
+++ b/src/utils/localStorageNotes.ts
@@ -54,3 +54,24 @@ export const editGuestNotes = ({ id, title, content }: EditNote): EditGuestNoteR
         return { success: false, message: "Error editing note, please try again" };
     }
 };
+
+export const deleteGuestNotes = (id: Number) => {
+    try {
+        const notes = getGuestNotes();
+        const updatedNotes = notes.filter(note => note.id !== id);
+
+        if (updatedNotes.length === notes.length) {
+            return { success: false, message: "We can't find your note!" };
+        }
+
+        localStorage.setItem("localStorageNotes", JSON.stringify(updatedNotes));
+        return { success: true, status: 200, message: "Note deleted!" };
+    } catch (error) {
+        if (error instanceof Error) {
+            console.error("Error deleting note, try again", error.message);
+        } else {
+            console.error("Error deleting note, try again", error);
+        }
+        return { success: false, message: "Error deleting note, please try again" };
+    }
+};

--- a/src/utils/localStorageNotes.ts
+++ b/src/utils/localStorageNotes.ts
@@ -1,8 +1,8 @@
 import { NewNote } from "../types/types";
 
-export const saveGuestNotes = (notes: NewNote[]) => {
+export const saveGuestNote = (note: NewNote) => {
     try {
-        localStorage.setItem("localStorageNotes", JSON.stringify(notes));
+        localStorage.setItem("localStorageNotes", JSON.stringify(note));
     } catch (error) {
         console.error("Something went wrong, sorry", error);
     }
@@ -12,7 +12,8 @@ export const getGuestNotes = () => {
     try {
         const guestNotes = localStorage.getItem("localStorageNotes");
         if (!guestNotes) return [];
-        return JSON.parse(guestNotes) as NewNote[];
+        const parsed = JSON.parse(guestNotes);
+        return Array.isArray(parsed) ? parsed as NewNote[] : [parsed] as NewNote[]; //it always returns array for redux parsing
     } catch (error) {
         if (error instanceof Error) {
             console.error("Error loading notes, try again", error.message);

--- a/src/utils/localStorageNotes.ts
+++ b/src/utils/localStorageNotes.ts
@@ -12,8 +12,13 @@ export const getGuestNotes = () => {
     try {
         const guestNotes = localStorage.getItem("localStorageNotes");
         if (!guestNotes) return [];
-        return JSON.parse(guestNotes);
+        return JSON.parse(guestNotes) as NewNote[];
     } catch (error) {
+        if (error instanceof Error) {
+            console.error("Error loading notes, try again", error.message);
+        } else {
+            console.error("Error loading notes, try again", error);
+        }
         return [];
     }
 };

--- a/src/utils/parseNotes.ts
+++ b/src/utils/parseNotes.ts
@@ -1,0 +1,47 @@
+import { NewNote, Note, NoteForRedux } from "@/types/types";
+
+export const parseLocalNotes = (localNotes: NewNote[]): NoteForRedux[] => {
+    const parsedNotes = localNotes.map(note => ({
+        id: new Date().getTime(),
+        title: note.title,
+        content: note.content,
+        important: note.important ?? false,
+        color: note.color ?? "default",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        userId: null,
+    }));
+    return parsedNotes;
+};
+
+export const parseLocalNote = (localNote: NewNote): NoteForRedux => {
+    const parsedNote = {
+        id: new Date().getTime(),
+        title: localNote.title,
+        content: localNote.content,
+        important: localNote.important ?? false,
+        color: localNote.color ?? "default",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        userId: null,
+    };
+    return parsedNote;
+};
+
+export const parseNotesFromDb = (notes: Note[]): NoteForRedux[] => {
+    const parsedNotes = notes.map(note => ({
+        ...note,
+        createdAt: typeof note.createdAt === "string" ? note.createdAt : note.createdAt.toISOString(),
+        updatedAt: typeof note.updatedAt === "string" ? note.updatedAt : note.updatedAt.toISOString(),
+    }));
+    return parsedNotes;
+};
+
+export const parseNoteFromDb = (note: Note): NoteForRedux => {
+    const parsedNote = {
+        ...note,
+        createdAt: typeof note.createdAt === "string" ? note.createdAt : note.createdAt.toISOString(),
+        updatedAt: typeof note.updatedAt === "string" ? note.updatedAt : note.updatedAt.toISOString(),
+    };
+    return parsedNote;
+};


### PR DESCRIPTION
This PR introduces localStorage persistance for notes with no users, aka notes for guest (users without a session). It implements localStorage-based CRUD and the refactoring of note-related types and logic to unify both guest and authenticated users flow. It also standardizes note data structures throughout the code.

**Guest note management and localStorage integration:**

* Added new utility functions in `src/utils/localStorageNotes.ts` to handle saving, retrieving, editing, and deleting notes for guest users using localStorage.
* Updated note creation, editing, deletion, and initialization hooks (`useCreateNote`, `useEditNote`, `useDeleteNote`, `useNotesInit`) to branch logic based on session presence, using localStorage for guests and the database for authenticated users. 

**Note type refactoring and parsing:**

* Introduced `NoteForRedux` and updated components and hooks affected by the typing.
* Added parsing util in `src/utils/parseNotes.ts` to convert notes from localStorage and database formats into the unified Redux format that the local context is now using to avoid future bug with Redux.

**Test updates:**

* Updated tests and interfaces to reflect new types (`NoteForRedux` and `EditNote`).
* Replaced clickable `div` element with `button` for menu dropdown new structure and added `aria-label="Opciones"`.